### PR TITLE
Corrections de diverses typos

### DIFF
--- a/GUTenberg Projets.tex
+++ b/GUTenberg Projets.tex
@@ -36,7 +36,7 @@ L'association GUTenberg doit donc penser son avenir, eu égard à ces nouveaux p
 	
 Ce document présente donc sommairement, à partir des discussions qui ont eu lieu sur les listes de diffusion, les différentes missions que l'association GUTenberg pourrait remplir. Celles-ci pourraient guider nos futurs projets et actions, sous réserve de trouver des bénévoles pour se charger de les mettre en œuvre.
 
-Pour relancer l'association, il faudra toutefois choisir de porter des projets à la hauteur de nos capacités, et donc hiérarchiser les projets à mettre en œuvre, quitte à ce que certains d'entre-eux restent en attente.
+Pour relancer l'association, il faudra toutefois choisir de porter des projets à la hauteur de nos capacités, et donc hiérarchiser les projets à mettre en œuvre, quitte à ce que certains d'entre eux restent en attente.
 
 \tableofcontents
 
@@ -48,9 +48,9 @@ Pour relancer l'association, il faudra toutefois choisir de porter des projets �
 L'Assemblée générale\ratio[Investissement régulier et dans la durée, les mandats durant 4 ans]{+++}{+++} devra, en premier lieu, élire un Conseil d'administration. Celui-ci comprend un bureau composé de trois à six membres assurant la gestion au quotidien de l'association. L'existence de cet organe est vitale pour le fonctionnement de GUTenberg:
 
 \begin{enumerate}
-	\item\textsc{Un président} et, le cas échéant, un vice-président, dont la fonction est de présider l'Assemblée générale, de représenter l'association à l'égard des tiers et en justice, et qui exerce une voix prépondérante en cas de partage.
-	\item\textsc{Un secrétaire}\footnote{Volontaire: Patrick \bsc{Bideault}~(pas seul).} et, le cas échéant, un vice-secrétaire, qui assurent la gestion courante de l'association, notamment l'envoi de courriers ou de mails informatifs aux membres de l'association, l'envoi des convocations aux assemblées générales et l'envoi de messages de rappel pour les cotisations.
-	\item\textsc{Un trésorier} et, le cas échéant, un vice-trésorier, qui assurent la gestion financière et comptable de l'association en gérant les comptes bancaires de celle-ci, la perception des cotisations par Paypal et par chèque, ainsi que la libération de fonds pour les dépenses courantes~(serveur, communication, assemblées générales) et celles spécialement approuvées par le Conseil d'administration~(Journées \LaTeX, etc.).
+	\item\textsc{Un président} et, le cas échéant, un vice-président, dont la fonction est de présider l'Assemblée générale, de représenter l'association à l'égard des tiers et en justice, et qui exerce une voix prépondérante en cas de partage ;
+	\item\textsc{Un secrétaire}\footnote{Volontaire: Patrick \bsc{Bideault}~(pas seul).} et, le cas échéant, un vice-secrétaire, qui assurent la gestion courante de l'association, notamment l'envoi de courriers ou de mails informatifs aux membres de l'association, l'envoi des convocations aux assemblées générales et l'envoi de messages de rappel pour les cotisations ;
+	\item\textsc{Un trésorier} et, le cas échéant, un vice-trésorier, qui assurent la gestion financière et comptable de l'association en gérant les comptes bancaires de celle-ci, la perception des cotisations par PayPal et par chèque, ainsi que la libération de fonds pour les dépenses courantes~(serveur, communication, assemblées générales) et celles spécialement approuvées par le Conseil d'administration~(Journées \LaTeX, etc.).
 \end{enumerate}
 
 \textsc{Jusqu'à six autres membres} pourront être désignés pour le Conseil d'administration, selon les vocations, qui pourraient inclure les personnes qui acceptent de coordonner certains projets, car elles participeront activement à la vie de l'association et auront besoin de se concerter avec le bureau.
@@ -62,16 +62,16 @@ Le site web pourrait s'étoffer pour proposer un des contenus destinés aux util
 Afin de répondre aux questions de nombreux utilisateurs, notamment débutants, nous envisageons la production des contenus suivants:
 
 \begin{enumerate}
-	\item\textsc{Rédaction d'une FAQ}\ratio[Effort collectif possible]{+++}{+++} en français\footnote{Volontaires: Patrick \bsc{Bideault}, Maxime \bsc{Chupin}, Denis \bsc{Bitouzé}.}, destinée aux nouveaux utilisateurs, qui pourrait se baser sur une traduction du site \url{<https://texfaq.org/>}, qui est distribuée sous une licence libre, et nourrie de questions posées sur les sites Q\&A comme \TeX nique.fr. Les \textsc{faq}s existantes sont incomplètes ou obsolètes.
+	\item\textsc{Rédaction d'une FAQ}\ratio[Effort collectif possible]{+++}{+++} en français\footnote{Volontaires: Patrick \bsc{Bideault}, Maxime \bsc{Chupin}, Denis \bsc{Bitouzé}.}, destinée aux nouveaux utilisateurs, qui pourrait se baser sur une traduction du site \url{<https://texfaq.org/>}, qui est distribuée sous une licence libre, et nourrie de questions posées sur les sites Q\&A comme \TeX nique.fr. Les \textsc{faq}s existantes sont incomplètes ou obsolètes ;
 	\item\textsc{Création d'une base de snippets}\ratio[Petites contributions régulières, sur le long terme]{++}{+++}  expliqués, pour le bénéfice de tous. Ceux-ci pourraient provenir de nos productions personnelles, mais aussi de la mise en forme de certaines réponses données sur TeX-SX ou \TeX nique.fr.
 \end{enumerate}
 
 Plusieurs propositions\ratio[Contributions substantielles, mais réparties entre les auteurs]{+++}{+++} ont été faites dans la logique des Cahiers GUTenberg ou, du moins, de productions plus substantielles qui pourraient être réparties entre plusieurs contributeurs sur un même thème, et publiées au fil de l'eau pour être éventuellement regroupées en cahiers par la suite:
 
 \begin{enumerate}
-	\item\textsc{Notices d'information}\ratio[Individuellement assez peu chronophage, d'autant que certaines ressources existent]{++}{+++} en français, rédigées par un spécialiste, pour l'initiation ou l'approfondissement de certains logiciels, pratiques ou nouveautés dans le monde \TeX\ (Con\TeX t, \LuaTeX, etc.), ainsi que de tutoriels sur l'utilisation des bibliographies (Bib\LaTeX avec Biber, récupération de bibliographies Zotero, etc.).
-	\item\textsc{Travail de documentation}\ratio[Plus ou moins chronophage selon les projets]{++}{+++}\footnote{Volontaire: Thomas \bsc{Savary}~(pas seul).}: création de fiches sur les principaux moteurs avec leurs avantages et inconvénients, création (ou traduction) de documentation sur la création de classes et packages pour personnaliser les outils existants, et traduction en français ou réduction sous forme de fiches pratiques des documentations des principales classes (Memoir, KOMA, etc.).
-	\item\textsc{Rédaction de \LaTeX, pourquoi?}\ratio[Plusieurs contributions sont dans les tuyaux]{++}{+++}\footnote{Coordinateur: Patrick \bsc{Bideault}.\par\noindent Volontaires: Éric \bsc{Guichard}, Flora \bsc{Vern}.}, qui avait été envisage pour le dernier Cahier, mais qui pourrait également prendre la forme de divers articles publiés sur le site de l'association~(ce qui permettrait des ajouts au fil de l'eau) en mettant l'accent sur les exemples pratiques d'utilisation de \LaTeX\ dans un contexte professionnel.
+	\item\textsc{Notices d'information}\ratio[Individuellement assez peu chronophage, d'autant que certaines ressources existent]{++}{+++} en français, rédigées par un spécialiste, pour l'initiation ou l'approfondissement de certains logiciels, pratiques ou nouveautés dans le monde \TeX\ (Con\TeX t, \LuaTeX, etc.), ainsi que de tutoriels sur l'utilisation des bibliographies (Bib\LaTeX avec Biber, récupération de bibliographies Zotero, etc.) ;
+	\item\textsc{Travail de documentation}\ratio[Plus ou moins chronophage selon les projets]{++}{+++}\footnote{Volontaire: Thomas \bsc{Savary}~(pas seul).}: création de fiches sur les principaux moteurs avec leurs avantages et inconvénients, création (ou traduction) de documentation sur la création de classes et packages pour personnaliser les outils existants, et traduction en français ou réduction sous forme de fiches pratiques des documentations des principales classes (Memoir, KOMA, etc.) ;
+	\item\textsc{Rédaction de \LaTeX, pourquoi?}\ratio[Plusieurs contributions sont dans les tuyaux]{++}{+++}\footnote{Coordinateur: Patrick \bsc{Bideault}.\par\noindent Volontaires: Éric \bsc{Guichard}, Flora \bsc{Vern}.}, qui avait été envisagé pour le dernier Cahier, mais qui pourrait également prendre la forme de divers articles publiés sur le site de l'association~(ce qui permettrait des ajouts au fil de l'eau) en mettant l'accent sur les exemples pratiques d'utilisation de \LaTeX\ dans un contexte professionnel.
 \end{enumerate}
 
 Pour faire honneur à notre logiciel préféré\ratio[Possibilité d'automatisation]{+}{+++}, nous pourrions prévoir, pour chaque article substantiel, une \textsc{version \LaTeX\ téléchargeable en PDF}. Pour cela, il serait peut-être possible de réutiliser la feuille de style des Cahiers GUTenberg. À nouveau, une plateforme Git serait intéressante pour permettre aux utilisateurs de voir le code source des articles et de les compiler eux-mêmes.
@@ -82,9 +82,9 @@ Ces activités supposent la désignation d'un \textsc{coordinateur}\ratio[Potent
 \section{Création de contenus sur la typographie}
 
 \begin{enumerate}
-	\item\textsc{Publication d'une galerie}\ratio[Les documents existent]{+}{+++} de belle typographie réalisée avec \LaTeX, comme la reproduction d'ouvrages anciens ou en langues étrangères (hébreu, chinois, arabe), la création de livres ou de magasines plus beaux que ceux produits avec les logiciels comme InDesign, etc. pour montrer l'utilité et la simplicité de \LaTeX.
-	\item\textsc{Publication d'articles sur la typographie}\ratio[Individuellement assez peu chronophage, d'autant que certaines ressources existent]{++}{++}\footnote{Volontaires: Thomas \bsc{Savary}, Flora \bsc{Vern}.}, notamment sur les différentes polices d'écriture et leur emploi, sur le format OpenType, la classification Vox-Atypi, Metafont, etc., avec des informations sur leur intégration pratique aux documents \TeX.
-	\item\textsc{Publication de contenus sur l'édition numérique}\ratio[Individuellement assez peu chronophage, d'autant que certaines ressources existent]{++}{++}\footnote{Volontaires: Thomas \bsc{Savary}.}, notamment sur les problèmes de composition typographique (lignes blanches, lignes à voleur, lignes creuses, rivières, veuves et orphelines, etc.) et sur l'intégration de \LaTeX\ dans la chaîne éditoriale, grâce aux logiciels permettant la conversion de Markdown vers \TeX, ou inversement de \TeX\ vers \textsc{html} ou word.
+	\item\textsc{Publication d'une galerie}\ratio[Les documents existent]{+}{+++} de belle typographie réalisée avec \LaTeX, comme la reproduction d'ouvrages anciens ou en langues étrangères (hébreu, chinois, arabe), la création de livres ou de magasines plus beaux que ceux produits avec les logiciels comme InDesign, etc. pour montrer l'utilité et la simplicité de \LaTeX ;
+	\item\textsc{Publication d'articles sur la typographie}\ratio[Individuellement assez peu chronophage, d'autant que certaines ressources existent]{++}{++}\footnote{Volontaires: Thomas \bsc{Savary}, Flora \bsc{Vern}.}, notamment sur les différentes polices d'écriture et leur emploi, sur le format OpenType, la classification Vox-Atypi, Metafont, etc., avec des informations sur leur intégration pratique aux documents \TeX ;
+	\item\textsc{Publication de contenus sur l'édition numérique}\ratio[Individuellement assez peu chronophage, d'autant que certaines ressources existent]{++}{++}\footnote{Volontaires: Thomas \bsc{Savary}.}, notamment sur les problèmes de composition typographique (lignes blanches, lignes à voleur, lignes creuses, rivières, veuves et orphelines, etc.) et sur l'intégration de \LaTeX\ dans la chaîne éditoriale, grâce aux logiciels permettant la conversion de Markdown vers \TeX, ou inversement de \TeX\ vers \textsc{html} ou Word ;
 	\item\textsc{Traduction de textes fondateurs}\ratio[Chronophage]{+++}{+}\footnote{Volontaire: Patrick \bsc{Bideault}.} du monde \TeX\ ou de la typographie française et étrangère, avec l'accord des auteurs. Jacques \bsc{André} mentionne des traductions par René \bsc{Fritz}; Patrick \bsc{Bideault} propose une adaptation des \emph{Métamorphoses de l'esperluette} de Jan \bsc{Tschichold}, avec les polices \TeX~(et des fontes libres?).
 \end{enumerate}
 
@@ -94,18 +94,18 @@ Ces activités supposent la désignation d'un \textsc{coordinateur}\ratio[Potent
 Afin de familiariser les néophytes avec \LaTeX\ratio[Petites contributions, par les connaisseurs]{++}{+++}, nous pourrons développer des scripts ou des outils en ligne, qui seraient intégrés sur le site de GUTenberg:
 
 \begin{enumerate}
-	\item\textsc{Convertisseur en ligne} pour permettre la conversion en ligne de documents entre les différents formats standard de l'édition grâce à Pandoc: fichier .tex avec bibliographie vers word, en \textsc{html} ou en diapositives. Un choix de formats .csl (styles bibliograpiquess) sera  proposé à l'utilisateur.
+	\item\textsc{Convertisseur en ligne} pour permettre la conversion en ligne de documents entre les différents formats standard de l'édition grâce à Pandoc: fichier .tex avec bibliographie vers Word, en \textsc{html} ou en diapositives. Un choix de formats .csl (styles bibliograpiquess) sera  proposé à l'utilisateur ;
 	\item\textsc{Scripts d'automatisation}\footnote{Volontaire: Thomas \bsc{Savary}.} permettant la conversion de documents Word ou ODT vers \LaTeX.
 \end{enumerate}
 
 
 \section{Journées \LaTeX}
 
-L'organisation des \textsc{Journées \LaTeX}\ratio[Coûteuses, mais utiles et susceptibles de s'intégrer dans les autres projets]{+++}{+++}\footnote{Volontaires: Éric \bsc{Guichard}, Jérémy \bsc{Just}, Flora \bsc{Vern}.} a un coût significatif pour l'association et pour ses membres, mais qui peut être partagé (par des formations doctorales, etc.). Il permet des exposés de qualité susceptibles de nourrir les Cahiers GUTenberg et de \emph{vulgariser} \LaTeX. La tenue des ces journées GUTenberg est importante pour la vie de l'association. C'est également un moment convivial.
+L'organisation des \textsc{Journées \LaTeX}\ratio[Coûteuses, mais utiles et susceptibles de s'intégrer dans les autres projets]{+++}{+++}\footnote{Volontaires: Éric \bsc{Guichard}, Jérémy \bsc{Just}, Flora \bsc{Vern}.} a un coût significatif pour l'association et pour ses membres, mais qui peut être partagé (par des formations doctorales, etc.). Il permet des exposés de qualité susceptibles de nourrir les Cahiers GUTenberg et de \emph{vulgariser} \LaTeX. La tenue de ces journées GUTenberg est importante pour la vie de l'association. C'est également un moment convivial.
 
 \begin{enumerate}
-	\item Elles pourraient être élargies à des publics variés (\emph{cf.} \url{<http://barthes.enssib.fr/LaTeX-2017>}) et réorganisées autour d'\textsc{actions de formation} avec des exposés d'initiation à \LaTeX\ (\emph{cf.} sur les stages) pour attirer un plus large public.
-	\item Elles pourraient bien sûr mêler à ces activités de formation des interventions plus \TeX niques, pour permettre notamment la diffusion des nouveautés et des développements dans le monde de \TeX\ et de celui de la typographie numérique.
+	\item Elles pourraient être élargies à des publics variés (\emph{cf.} \url{<http://barthes.enssib.fr/LaTeX-2017>}) et réorganisées autour d'\textsc{actions de formation} avec des exposés d'initiation à \LaTeX\ (\emph{cf.} sur les stages) pour attirer un plus large public ;
+	\item Elles pourraient bien sûr mêler à ces activités de formation des interventions plus \TeX niques, pour permettre notamment la diffusion des nouveautés et des développements dans le monde de \TeX\ et de celui de la typographie numérique ;
 	\item Elles pourraient aussi être \textsc{organisées autour des Assemblées générales} de l'association, en limitant le nombre de contributions pour laisser un temps de débats conviviaux.
 \end{enumerate}
 
@@ -115,8 +115,8 @@ L'organisation des \textsc{Journées \LaTeX}\ratio[Coûteuses, mais utiles et su
 Les \textsc{Cahiers GUTenberg}\ratio[Chronophage, mais utile à la communauté et susceptible de bénéficier des autres projets]{++}{+++} produisent des articles de qualité sur \LaTeX\ et la typographie. La revue est utile à beaucoup d'utilisateurs, mais difficile à faire vivre en raison des contraintes éditoriales, du caractère chronophage des relectures, et de la nécessité de réunir des contributions sur un même thème. En bref, il faudrait lui donner un vrai statut de revue scientifique.
 
 \begin{enumerate}
-	\item Elle pourrait, comme l'ont fait certains numéros, publier les \textsc{contributions des journées \LaTeX}, en plus de quelques articles soumis par des bénévoles, ce qui réduirait la charge de travail des rédacteurs.
-	\item Elle pourrait également bénéficier des \textsc{publications au fil de l'eau} sur le site web, qui pourraient être orientées autour d'un thème, puis compilées sous forme de revue lorsque les publications se multiplient (en comptant sur l'effet d'entraînement plutôt que sur la date butoir de soumission des articles).
+	\item Elle pourrait, comme l'ont fait certains numéros, publier les \textsc{contributions des journées \LaTeX}, en plus de quelques articles soumis par des bénévoles, ce qui réduirait la charge de travail des rédacteurs ;
+	\item Elle pourrait également bénéficier des \textsc{publications au fil de l'eau} sur le site web, qui pourraient être orientées autour d'un thème, puis compilées sous forme de revue lorsque les publications se multiplient (en comptant sur l'effet d'entraînement plutôt que sur la date butoir de soumission des articles) ;
 	\item Elle pourrait enfin \textsc{récupérer ou traduire des articles sur \LaTeX} publiés en d'autres revues et des guides d'initiation qui diffèrent des manuels existants.
 \end{enumerate}
 
@@ -151,8 +151,8 @@ Cet annuaire permettrait seulement la mise en relation des spécialistes avec le
 On note la multiplicité actuelle des listes de diffusion, qui sont hébergées sur un serveur de l'École normale supérieure~{\bsc{ens}) auquel nous n'avons pas accès, ce qui interdit la constitution d'archives. La diffusion des activités de l'association pourrait être recentrée:
 
 \begin{enumerate}
-	\item Possibilité de créer\ratio[Simple, mais \emph{quid} de l'efficacité]{+}{+} une liste de diffusion propre à l'association et hébergée sur son propre serveur, qui aurait vocation à se substituer (à long terme) aux listes \url{<gut@ens.fr>} et \url{<metafont@ens.fr>}, à condition que les membres utilisent les nouveaux outils ainsi créés.
-	\item Possibilité de créer~(en plus) une newsletter\ratio[Simple et utile pour toucher davantage d'utilisateurs]{+}{++} pour les membres de l'association~(et les tiers intéressés?), notamment afin de les tenir informés de nos activités, des journées \LaTeX, des publications, etc. au moyen d'un système de mailing automatique, plutôt que d'envoyer des lettres imprimées.
+	\item Possibilité de créer\ratio[Simple, mais \emph{quid} de l'efficacité]{+}{+} une liste de diffusion propre à l'association et hébergée sur son propre serveur, qui aurait vocation à se substituer (à long terme) aux listes \url{<gut@ens.fr>} et \url{<metafont@ens.fr>}, à condition que les membres utilisent les nouveaux outils ainsi créés ;
+	\item Possibilité de créer~(en plus) une newsletter\ratio[Simple et utile pour toucher davantage d'utilisateurs]{+}{++} pour les membres de l'association~(et les tiers intéressés?), notamment afin de les tenir informés de nos activités, des journées \LaTeX, des publications, etc. au moyen d'un système de mailing automatique, plutôt que d'envoyer des lettres imprimées ;
 	\item Possibilité de coupler certaines modifications\ratio[Atteindre de nouveaux publics, mais ces médias correspondent-ils à notre philosophie?]{++}{+} du site web avec des posts automatiques sur certains réseaux sociaux, grâce à des logiciels ou scripts spécialités. Cela suppose qu'une personne utilise lesdits réseaux sociaux pour répondre aux commentaires. Les posts automatiques permettent d'alléger une partie du travail sur les réseaux sociaux, mais la tâche demeure chronophage.
 \end{enumerate}
 
@@ -167,24 +167,24 @@ La question a été posée\ratio[Relativement chronophage et coûteux]{++}{+} de
 Le site web devra faire l'objet d'une refonte\ratio[Travail intense, mais limité dans le temps.]{+++}{+++}\footnote{Volontaires: Laurent \bsc{Bloch}, Maïeul \bsc{Rouquette}.} plus ou moins importante afin de devenir plus attractif et de pouvoir accueillir les divers projets de l'association.
 
 \begin{enumerate}
-	\item\textsc{Refonte graphique du site web} avec avec un nouveau squelette, plus attrayant.
-	\item\textsc{Restructuration du site web}, notamment les catégories de contenus et d'utilisateurs, afin que tous les intéressés aient puissent rédiger des contenus.
-	\item Les \textsc{Cahiers GUTenberg} pourraient être hébergés sur le site de l'association, pour davantage de lisibilité, avec une présentation~(résumé) de chaque numéro, et le résumé français des articles (qui existe déjà), suivi du lien vers le document PDF pour en faciliter l'accès et la lecture.
+	\item\textsc{Refonte graphique du site web} avec avec un nouveau squelette, plus attrayant ;
+	\item\textsc{Restructuration du site web}, notamment les catégories de contenus et d'utilisateurs, afin que tous les intéressés aient puissent rédiger des contenus ;
+	\item Les \textsc{Cahiers GUTenberg} pourraient être hébergés sur le site de l'association, pour davantage de lisibilité, avec une présentation~(résumé) de chaque numéro, et le résumé français des articles (qui existe déjà), suivi du lien vers le document PDF pour en faciliter l'accès et la lecture ;
 	\item Possibilité pour celui ou celle qui se chargera de cette refonte de \textsc{choisir un autre moteur} pour le site~(actuellement SPIP).
 \end{enumerate}
 
 Il serait possible de revoir, sans réels coûts\ratio[Travail limité dans le temps]{+}{+++}, l'organisation du site internet afin de mettre en valeur certains éléments essentiels\footnote{Volontaires: Maxime \bsc{Chupin}, Flora \bsc{Vern}.}:
 
 \begin{enumerate}
-	\item Revoir les \textsc{pages de présentation et d'adhésion} pour les rendre plus attractives, en présentant notamment \LaTeX\ dès la page d'accueil du site.
-	\item Insérer une \textsc{liste de liens utiles}, notamment pour mettre en valeur le site \TeX nique.fr, le TUG et des sites ou forums francophones et anglophones/
-	\item Une page du site web pourrait \textsc{présenter les distributions} avec un tutoriel et des liens vers les installateurs pour chaque machine (Linux, OSX, Windows).
+	\item Revoir les \textsc{pages de présentation et d'adhésion} pour les rendre plus attractives, en présentant notamment \LaTeX\ dès la page d'accueil du site ;
+	\item Insérer une \textsc{liste de liens utiles}, notamment pour mettre en valeur le site \TeX nique.fr, le TUG et des sites ou forums francophones et anglophones ;
+	\item Une page du site web pourrait \textsc{présenter les distributions} avec un tutoriel et des liens vers les installateurs pour chaque machine (Linux, macOS, Windows).
 \end{enumerate}
 
 Il faudrait également qu'une personne compétente\ratio[Compétence très spécifique]{+}{+++} \textsc{administre le serveur Linux} sur lequel le site est hébergé, et qui pourrait supporter les projets de la communauté, au-delà du site web. Dans ce cadre, deux services pourraient être proposés:
 
 \begin{enumerate}
-	\item Le \textsc{site \TeX nique.fr}\ratio[Le site est déjà fonctionnel en l'état]{++}{+}, qui est construit sur un modèle analogue à celui de \url{<tex.stackexchange>}, est actuellement fonctionnel mais hébergé sur un serveur sur lequel nous n'avons pas la main. Son transfert pourrait faire l'objet d'une réflexion.
+	\item Le \textsc{site \TeX nique.fr}\ratio[Le site est déjà fonctionnel en l'état]{++}{+}, qui est construit sur un modèle analogue à celui de \url{<tex.stackexchange>}, est actuellement fonctionnel mais hébergé sur un serveur sur lequel nous n'avons pas la main. Son transfert pourrait faire l'objet d'une réflexion ;
 	\item Création d'un \textsc{système de suivi de version basé sur Git}\ratio[On peut créer un Github ou un FramaGit collectifs]{++}{+}, pour travailler collectivement sur les contributions des membres de la communauté.
 \end{enumerate}
 


### PR DESCRIPTION
Parmi les grosses modifications, les éléments d'une liste se terminant normalement par un point-virgule sauf le dernier, j'ai donc corrigé cela. J'ai également corrigé certains noms de marque (Paypal -> PayPal, word -> Word, OSX -> macOS [car le nom du système d'exploitation des ordinateurs Mac a été modifié depuis quelques années]).